### PR TITLE
Added extra opentelemetry data points

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -204,3 +204,14 @@ gem 'net-http', '~> 0.3.2'
 gem 'rubyzip', '~> 2.3'
 
 gem 'hcaptcha', '~> 7.1'
+
+# Jaeger Opentelemetry
+gem 'opentelemetry-sdk'
+gem 'opentelemetry-api'
+gem 'opentelemetry-exporter-jaeger'
+gem 'opentelemetry-instrumentation-rack'
+gem 'opentelemetry-instrumentation-rails'
+gem 'opentelemetry-instrumentation-action_pack'
+gem 'opentelemetry-instrumentation-active_job'
+gem 'opentelemetry-instrumentation-active_model_serializers'
+gem 'opentelemetry-instrumentation-active_record'

--- a/Gemfile
+++ b/Gemfile
@@ -207,5 +207,6 @@ gem 'hcaptcha', '~> 7.1'
 
 # Jaeger Opentelemetry
 gem 'opentelemetry-sdk'
+gem 'opentelemetry-api'
 gem 'opentelemetry-exporter-jaeger'
 gem 'opentelemetry-instrumentation-all'

--- a/Gemfile
+++ b/Gemfile
@@ -207,11 +207,5 @@ gem 'hcaptcha', '~> 7.1'
 
 # Jaeger Opentelemetry
 gem 'opentelemetry-sdk'
-gem 'opentelemetry-api'
 gem 'opentelemetry-exporter-jaeger'
-gem 'opentelemetry-instrumentation-rack'
-gem 'opentelemetry-instrumentation-rails'
-gem 'opentelemetry-instrumentation-action_pack'
-gem 'opentelemetry-instrumentation-active_job'
-gem 'opentelemetry-instrumentation-active_model_serializers'
-gem 'opentelemetry-instrumentation-active_record'
+gem 'opentelemetry-instrumentation-all'

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,0 +1,31 @@
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/jaeger'
+require 'opentelemetry/instrumentation/rails'
+require 'opentelemetry/instrumentation/rack'
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'Mastodon'
+  c.service_version = '4.2.3'
+
+  # c.use 'OpenTelemetry::Instrumentation::ActionPack'
+  # c.use 'OpenTelemetry::Instrumentation::ActionView'
+  # c.use 'OpenTelemetry::Instrumentation::ActiveJob'
+  # c.use 'OpenTelemetry::Instrumentation::ActiveModelSerializers'
+  # c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
+  # c.use 'OpenTelemetry::Instrumentation::Rails'
+  # c.use 'OpenTelemetry::Instrumentation::Rack', {
+  #   allowed_request_headers: :all,
+  #   allowed_response_headers: :all
+  # }
+
+  c.use_all
+
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      OpenTelemetry::Exporter::Jaeger::AgentExporter.new(
+        host: ENV['JAEGER_HOST'] || 'localhost',
+        port: ENV['JAEGER_PORT'] || 6831
+      )
+    )
+  )
+end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,24 +1,43 @@
 require 'opentelemetry/sdk'
 require 'opentelemetry/exporter/jaeger'
-require 'opentelemetry/instrumentation/rails'
-require 'opentelemetry/instrumentation/rack'
+require 'opentelemetry/instrumentation/all'
 
 OpenTelemetry::SDK.configure do |c|
   c.service_name = 'Mastodon'
   c.service_version = '4.2.3'
 
-  # c.use 'OpenTelemetry::Instrumentation::ActionPack'
-  # c.use 'OpenTelemetry::Instrumentation::ActionView'
-  # c.use 'OpenTelemetry::Instrumentation::ActiveJob'
-  # c.use 'OpenTelemetry::Instrumentation::ActiveModelSerializers'
-  # c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
-  # c.use 'OpenTelemetry::Instrumentation::Rails'
-  # c.use 'OpenTelemetry::Instrumentation::Rack', {
-  #   allowed_request_headers: :all,
-  #   allowed_response_headers: :all
-  # }
+  config = {
+    'OpenTelemetry::Instrumentation::Rack' => {
+      record_frontend_span: true,
+      allowed_request_headers: :all,
+      allowed_response_headers: :all
+    },
+    'OpenTelemetry::Instrumentation::ActiveRecord' => {
+      enable_sql_obfuscation: false,
+    },
+    'OpenTelemetry::Instrumentation::Redis' => {
+      capture_arguments: true,
+      db_statement: :include
+    },
+    'OpenTelemetry::Instrumentation::Postgres' => {
+      enable_sql_obfuscation: false,
+      db_statement: :include
+    },
+    'OpenTelemetry::Instrumentation::Sidekiq' => {
+      span_naming: :job_class,
+      propagation_style: :link
+    },
+    'OpenTelemetry::Instrumentation::Excon' => {
+      # List of hosts to be excluded from otel tracing
+      untraced_hosts: [],
+      peer_services: 'NameOfExternalService'
+    },
+    'OpenTelemetry::Instrumentation::Faraday' => {
+      peer_service: 'NameOfExternalService'
+    }
+  }
 
-  c.use_all
+  c.use_all(config)
 
   c.add_span_processor(
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(


### PR DESCRIPTION
Added extra open-telemetry data and exposed the following:

* Rack request and response headers
* All PostgreSQL queries with details
* All Redis calls and commands with details
* More Sidekiq information
* Excon and Faraday external services (I have not tested exactly the data it exposes because I do not have access to a proper mastodon copy of production) 